### PR TITLE
Change app buttons to download

### DIFF
--- a/index.html
+++ b/index.html
@@ -493,12 +493,12 @@
             <div class="app-card fade-in">
                 <h3>Third Eye Timer</h3>
                 <p>Transform your meditation practice with 100+ guided meditations, real-time heart rate tracking, and a comprehensive achievements system. Build daily meditation streaks, track your progress, and unlock your inner potential through scientifically-backed mindfulness techniques.</p>
-                <a href="https://play.google.com/store/apps/details?id=com.thirdeyetimer.app" target="_blank">Explore Now</a>
+                <a href="https://play.google.com/store/apps/details?id=com.thirdeyetimer.app" target="_blank">Download</a>
             </div>
             <div class="app-card fade-in">
                 <h3>Hello German</h3>
                 <p>Master the German language with interactive lessons, pronunciation guides, and cultural insights. Perfect for beginners and advanced learners alike.</p>
-                <a href="https://play.google.com/store/apps/details?id=com.hellogerman.app" target="_blank">Explore Now</a>
+                <a href="https://play.google.com/store/apps/details?id=com.hellogerman.app" target="_blank">Download</a>
             </div>
             <div class="app-card fade-in">
                 <h3>App 3</h3>


### PR DESCRIPTION
Change 'Explore Now' buttons to 'Download' buttons for 'Third Eye Timer' and 'Hello German' apps as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d1225a8-259f-4aea-824e-78f7e45493db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6d1225a8-259f-4aea-824e-78f7e45493db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

