### PR TITLE
Set thirdeye.png as app icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Brihath - Innovative Creations</title>
+    
+    <!-- App Icons -->
+    <link rel="icon" type="image/png" href="thirdeye.png">
+    <link rel="apple-touch-icon" href="thirdeye.png">
+    <link rel="shortcut icon" href="thirdeye.png">
+    <meta name="msapplication-TileImage" content="thirdeye.png">
+    <meta name="msapplication-TileColor" content="#00ffcc">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
         :root {


### PR DESCRIPTION
Add `thirdeye.png` as the app icon for the Third Eye Timer app to ensure proper display across platforms and browsers.

---
<a href="https://cursor.com/background-agent?bcId=bc-664810d1-f447-4632-afed-872e6f7d6c82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-664810d1-f447-4632-afed-872e6f7d6c82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

