### PR TITLE
Set hellogerman.png as app icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -514,6 +514,7 @@
                 <a href="https://play.google.com/store/apps/details?id=com.thirdeyetimer.app" target="_blank">Download</a>
             </div>
             <div class="app-card fade-in">
+                <img src="hellogerman.png" alt="Hello German" class="app-icon">
                 <h3>Hello German</h3>
                 <p>Master the German language with interactive lessons, pronunciation guides, and cultural insights. Perfect for beginners and advanced learners alike.</p>
                 <a href="https://play.google.com/store/apps/details?id=com.hellogerman.app" target="_blank">Download</a>


### PR DESCRIPTION
Add `hellogerman.png` as the app icon for the Hello German app to display it near the app title.

---
<a href="https://cursor.com/background-agent?bcId=bc-5aeb737a-2830-40f7-8f26-ff3ec0cd78e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5aeb737a-2830-40f7-8f26-ff3ec0cd78e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

